### PR TITLE
Allow user to provide the memmap file for coordinates_to_maps

### DIFF
--- a/neuroquery/img_utils.py
+++ b/neuroquery/img_utils.py
@@ -87,7 +87,9 @@ def coordinates_to_maps(
                 for i, (pmid, article) in enumerate(all_articles)
             )
             output.flush()
-            return pd.DataFrame(np.array(output), index=pmids), masker
+            result = pd.DataFrame(np.array(output), index=pmids)
+            del output
+    return result, masker
 
 
 def iter_coordinates_to_maps(

--- a/neuroquery/img_utils.py
+++ b/neuroquery/img_utils.py
@@ -1,6 +1,6 @@
+import contextlib
 import tempfile
 from pathlib import Path
-import contextlib
 
 import numpy as np
 import pandas as pd
@@ -110,11 +110,10 @@ def coordinates_to_maps(
             for i, (pmid, article) in enumerate(all_articles)
         )
         output.flush()
-        if return_memmap:
-            result = pd.DataFrame(output, index=pmids)
-        else:
-            result = pd.DataFrame(np.array(output), index=pmids)
-        return result, masker
+        if not return_memmap:
+            # make an in-memory copy if the memmap is temporary
+            output = np.array(output)
+        return pd.DataFrame(output, index=pmids), masker
 
 
 def iter_coordinates_to_maps(

--- a/neuroquery/tests/test_img_utils.py
+++ b/neuroquery/tests/test_img_utils.py
@@ -98,7 +98,7 @@ def _coordinates_to_maps(
     ):
         images.append(masker.transform(img).ravel().astype("float32"))
         img_pmids.append(pmid)
-    return pd.DataFrame(images, index=img_pmids), masker
+    return pd.DataFrame(images, index=img_pmids, dtype="float32"), masker
 
 
 @pytest.mark.parametrize("persist_memmap", [True, False])

--- a/neuroquery/tests/test_img_utils.py
+++ b/neuroquery/tests/test_img_utils.py
@@ -54,7 +54,8 @@ def test_gaussian_coord_smoothing():
     assert values[-1] == pytest.approx(0.0)
 
 
-def test_coordinates_to_maps():
+@pytest.mark.parametrize("persist_memmap", [True, False])
+def test_coordinates_to_maps(persist_memmap, tmp_path):
     coords = pd.DataFrame.from_dict(
         {
             "pmid": [3, 17, 17, 2, 2],
@@ -63,7 +64,13 @@ def test_coordinates_to_maps():
             "z": [27.0, 0.0, 30.0, 17.0, 177.0],
         }
     )
-    maps, masker = img_utils.coordinates_to_maps(coords)
+    if persist_memmap:
+        memmap = tmp_path.joinpath("maps.dat")
+    else:
+        memmap = None
+    maps, masker = img_utils.coordinates_to_maps(
+        coords, output_memmap_file=memmap
+    )
     # nilearn mni mask changed
     assert maps.shape == (3, 28542) or maps.shape == (3, 29398)
     coords_17 = [(0.0, 0.0, 0.0), (10.0, -10.0, 30.0)]
@@ -82,17 +89,22 @@ def _coordinates_to_maps(
             coordinates.shape[0], len(set(coordinates["pmid"]))
         )
     )
-    masker = img_utils.get_masker(mask_img=mask_img, target_affine=target_affine)
+    masker = img_utils.get_masker(
+        mask_img=mask_img, target_affine=target_affine
+    )
     images, img_pmids = [], []
     for pmid, img in img_utils.iter_coordinates_to_maps(
         coordinates, mask_img=masker, fwhm=fwhm
     ):
-        images.append(masker.transform(img).ravel())
+        images.append(masker.transform(img).ravel().astype("float32"))
         img_pmids.append(pmid)
     return pd.DataFrame(images, index=img_pmids), masker
 
 
-def test_parallel_coordinates_to_maps_should_match_original_implementation():
+@pytest.mark.parametrize("persist_memmap", [True, False])
+def test_parallel_coordinates_to_maps_should_match_original_implementation(
+    persist_memmap, tmp_path
+):
     coords = pd.DataFrame.from_dict(
         {
             "pmid": [3, 17, 17, 2, 2],
@@ -101,8 +113,13 @@ def test_parallel_coordinates_to_maps_should_match_original_implementation():
             "z": [27.0, 0.0, 30.0, 17.0, 177.0],
         }
     )
-
-    maps, masker = img_utils.coordinates_to_maps(coords, n_jobs=2)
+    if persist_memmap:
+        memmap = tmp_path.joinpath("maps.dat")
+    else:
+        memmap = None
+    maps, masker = img_utils.coordinates_to_maps(
+        coords, n_jobs=2, output_memmap_file=memmap
+    )
     original_maps, original_masker = _coordinates_to_maps(coords)
 
     pd.testing.assert_frame_equal(maps, original_maps)

--- a/neuroquery/tests/test_img_utils.py
+++ b/neuroquery/tests/test_img_utils.py
@@ -113,10 +113,7 @@ def test_parallel_coordinates_to_maps_should_match_original_implementation(
             "z": [27.0, 0.0, 30.0, 17.0, 177.0],
         }
     )
-    if persist_memmap:
-        memmap = tmp_path.joinpath("maps.dat")
-    else:
-        memmap = None
+    memmap = tmp_path.joinpath("maps.dat") if persist_memmap else None
     maps, masker = img_utils.coordinates_to_maps(
         coords, n_jobs=2, output_memmap_file=memmap
     )


### PR DESCRIPTION
this allows the user to pass a file path as an argument; in that case the brain maps are stored in a memmap at that location, and the returned dataframe's data is that memmap. this makes it easier to use that function with limited memory. also, it stores the brain maps in float32 rather than 64